### PR TITLE
Fixed spelling mistakes in engineio & socketio

### DIFF
--- a/addons/godot-socketio/engineio.gd
+++ b/addons/godot-socketio/engineio.gd
@@ -23,8 +23,8 @@ enum State {
 }
 
 # to avoid missunderstanding/missusage, the engine signals have been prefixed with "engine_" to distinguish them from the socket.io signals
-signal engine_conncetion_opened()
-signal engine_conncetion_closed()
+signal engine_connection_opened()
+signal engine_connection_closed()
 signal engine_message_received(data: String)
 signal engine_transport_upgraded()
 
@@ -117,7 +117,7 @@ func engine_close():
 			_close_http_request.on_response_received.connect(_close_http_completed)
 			_close_http_request.request_post(_get_url(), str(EnginePacketType.CLOSE))
 
-	engine_conncetion_closed.emit()
+	engine_connection_closed.emit()
 	_clear_values()
 
 
@@ -201,7 +201,7 @@ func _on_open(body: String = ""):
 		_upgrade_transport()
 	else:
 		_transport_type = TransportType.POLLING
-		engine_conncetion_opened.emit()
+		engine_connection_opened.emit()
 		_poll()
 	
 
@@ -216,7 +216,7 @@ func _on_ping():
 func _on_pong():
 	_websocket_send(EnginePacketType.UPGRADE)
 	_transport_type = TransportType.WEBSOCKET
-	engine_conncetion_opened.emit()
+	engine_connection_opened.emit()
 
 
 func _on_message(body: String = ""):

--- a/addons/godot-socketio/socketio.gd
+++ b/addons/godot-socketio/socketio.gd
@@ -46,9 +46,9 @@ func _ready():
 		"auth": {}
 	}
 
-	engine_conncetion_opened.connect(_on_engine_io_conncetion_opened)
+	engine_connection_opened.connect(_on_engine_io_connection_opened)
 	engine_message_received.connect(_socket_parse_packet)
-	engine_conncetion_closed.connect(_on_engine_io_conncetion_closed)
+	engine_connection_closed.connect(_on_engine_io_connection_closed)
 
 
 ## connects to the default namespace of socket server
@@ -151,11 +151,11 @@ func disconnect_socket():
 	socket_disconnected.emit()
 
 
-func _on_engine_io_conncetion_closed():
+func _on_engine_io_connection_closed():
 	socket_disconnected.emit()
 
 
-func _on_engine_io_conncetion_opened():
+func _on_engine_io_connection_opened():
 	connect_to_namespace(default_namespace, _namespaces[default_namespace].auth)
 
 


### PR DESCRIPTION
The word "connection" was misspelled as "conncetion" in two files. This PR aims to fix that.