### PR TITLE
Handle reconnection for `godot-socketio`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a [Socket.IO](https://socket.io/) and [Engine.IO](https://socket.io/docs
 
 | Godot | plugin version | Socket.IO server |
 | -------------- | ---------------- | ---------------- |
-| 4.3, 4.4 | 0.1.x | 4.x |
+| 4.3, 4.4, 4.5, 4.6 | 0.1.x | 4.x |
 
 > I haven’t checked the current implementation with older versions of the Godot and Socket.IO server. I hereby ask you to do this and inform me if it works or not.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,62 @@ func _on_event_received(event: String, data: Variant, ns: String) -> void:
 | custom serializer            | ❌              | [Custom parser](https://socket.io/docs/v4/custom-parser/)
 | C# API            | ❌              | 
 
+## Testing the Example
+
+The [example/](example/) folder contains a ready-made Socket.IO server (`socket.js`) and a Godot project that exercises the client.
+
+### 0 — Link the addon into the example project
+
+The example project expects the addon at `example/addons/godot-socketio/`. Because Godot cannot load files outside the project root, a symlink is needed (run once):
+
+```bash
+mkdir -p example/addons
+ln -s ../../addons/godot-socketio example/addons/godot-socketio
+```
+
+### 1 — Start the Node.js server
+
+```bash
+cd example
+npm install        # first time only — installs socket.io
+node socket.js
+```
+
+The server listens on **http://localhost:3000**. Verify it is up:
+
+```bash
+curl "http://localhost:3000/socket.io/?EIO=4&transport=polling"
+# expected: 0{"sid":"...","upgrades":["websocket"],...}
+```
+
+### 2 — Open the Godot project
+
+Open Godot 4 and import `example/project.godot`. Make sure the **SocketIO** addon is enabled under *Project → Project Settings → Plugins*.
+
+### 3 — Run and interact
+
+Press **F5** (or the Play button) to run the scene. The UI exposes these actions:
+
+| Button | What it does |
+|---|---|
+| **Connect** | Connects to `ws://localhost:3000` (default namespace) |
+| **Emit ping** | Sends a `ping` event → server responds with `pong` |
+| **Emit search** | Sends a `search` event with `{"query": "Godot Engine", "limit": 5}` |
+| **Connect namespace** | Connects to the `/admin` namespace |
+| **Emit in admin** | Sends a `version` event → server responds with `{"version": "4.3"}` |
+
+Received events are printed in the Godot output panel and displayed in the on-screen log label.
+
+### 4 — What to look for on the server side
+
+The terminal running `node socket.js` will print:
+
+```
+connected to the default namespace
+search ->  { query: 'Godot Engine', limit: 5 }
+connected to the /admin namespace
+```
+
 ## License
 
 MIT

--- a/addons/godot-socketio/engineio.gd
+++ b/addons/godot-socketio/engineio.gd
@@ -39,7 +39,7 @@ const ENGINE_VERSION: int = 4
 @export var reconnect_base_delay_seconds: float = 1.0
 
 var session_id: String = ""
-var state = State.DISCONNECTED
+var state := State.DISCONNECTED
 
 var _websocket: WebSocketPeer
 var _polling_http_request: Request

--- a/addons/godot-socketio/engineio.gd
+++ b/addons/godot-socketio/engineio.gd
@@ -163,7 +163,10 @@ func _parse_packet(data: String):
 				_on_open(message)
 			EnginePacketType.CLOSE:
 				state = State.DISCONNECTED
-				engine_close()
+				if _transport_type == TransportType.WEBSOCKET:
+					_websocket.close()
+				else:
+					engine_close()
 			EnginePacketType.PING:
 				_on_ping()
 			EnginePacketType.PONG:

--- a/addons/godot-socketio/engineio.gd
+++ b/addons/godot-socketio/engineio.gd
@@ -27,7 +27,7 @@ signal engine_connection_opened()
 signal engine_connection_closed()
 signal engine_message_received(data: String)
 signal engine_transport_upgraded()
-signal reconnect_attempt(attempt: int, max: int)
+signal reconnection_attempted(attempt: int, max: int)
 
 const ENGINE_VERSION: int = 4
 
@@ -36,7 +36,7 @@ const ENGINE_VERSION: int = 4
 @export var path: String = "/engine.io"
 @export var auto_reconnect: bool = true
 @export var max_reconnect_attempts: int = 5
-@export var reconnect_base_delay: float = 1.0
+@export var reconnect_base_delay_seconds: float = 1.0
 
 var session_id: String = ""
 var state = State.DISCONNECTED
@@ -77,21 +77,13 @@ func _process(_delta):
 	elif _socket_state == WebSocketPeer.STATE_CLOSED:
 		if auto_reconnect and _reconnect_attempts < max_reconnect_attempts:
 			_reconnect_attempts += 1
-			reconnect_attempt.emit(_reconnect_attempts, max_reconnect_attempts)
-			session_id = ""
-			state = State.DISCONNECTED
-			_websocket = null
+			_clear_values()
 			_polling_http_request = null
 			_send_data_http_request = null
-			_send_data_queue.clear()
-			_probe_sent = false
-			_transport_type = TransportType.POLLING
-			_ping_interval = 0
-			_pong_timeout = 0
-			_max_payload = 0
 			var t := Timer.new()
-			t.wait_time = reconnect_base_delay * _reconnect_attempts
+			t.wait_time = reconnect_base_delay_seconds * _reconnect_attempts
 			t.one_shot = true
+			t.timeout.connect(_emit_reconnection_attempted)
 			t.timeout.connect(engine_make_connection)
 			t.timeout.connect(t.queue_free)
 			add_child(t)
@@ -160,6 +152,8 @@ func _clear_values():
 	_max_payload = 0
 	_reconnect_attempts = 0
 
+func _emit_reconnection_attempted():
+	reconnection_attempted.emit(_reconnect_attempts, max_reconnect_attempts)
 
 func _parse_packet(data: String):
 	var messages := data.split("")
@@ -243,6 +237,7 @@ func _on_ping():
 
 func _on_pong(payload: String = ""):
 	if payload != "probe":
+		push_warning("Received unexpected pong with payload: %s" % payload)
 		return
 	_websocket_send(EnginePacketType.UPGRADE)
 	_transport_type = TransportType.WEBSOCKET

--- a/addons/godot-socketio/engineio.gd
+++ b/addons/godot-socketio/engineio.gd
@@ -27,15 +27,19 @@ signal engine_connection_opened()
 signal engine_connection_closed()
 signal engine_message_received(data: String)
 signal engine_transport_upgraded()
+signal reconnect_attempt(attempt: int, max: int)
 
 const ENGINE_VERSION: int = 4
 
 @export var autoconnect: bool = true
 @export var base_url: String = "http://localhost"
 @export var path: String = "/engine.io"
+@export var auto_reconnect: bool = true
+@export var max_reconnect_attempts: int = 5
+@export var reconnect_base_delay: float = 1.0
 
 var session_id: String = ""
-var state: State = State.DISCONNECTED
+var state = State.DISCONNECTED
 
 var _websocket: WebSocketPeer
 var _polling_http_request: Request
@@ -43,10 +47,11 @@ var _send_data_http_request: Request
 var _close_http_request: Request
 var _send_data_queue: Array[String] = []
 var _probe_sent = false
-var _transport_type: TransportType = TransportType.POLLING
+var _transport_type = TransportType.POLLING
 var _ping_interval: int = 0
 var _pong_timeout: int = 0
 var _max_payload: int = 0
+var _reconnect_attempts: int = 0
 
 
 func _ready():
@@ -70,9 +75,30 @@ func _process(_delta):
 			if not packets.is_empty():
 				_parse_packet(packets)
 	elif _socket_state == WebSocketPeer.STATE_CLOSED:
-		# TODO: reconnect if needed
-		state = State.DISCONNECTED
-		engine_close()
+		if auto_reconnect and _reconnect_attempts < max_reconnect_attempts:
+			_reconnect_attempts += 1
+			reconnect_attempt.emit(_reconnect_attempts, max_reconnect_attempts)
+			session_id = ""
+			state = State.DISCONNECTED
+			_websocket = null
+			_polling_http_request = null
+			_send_data_http_request = null
+			_send_data_queue.clear()
+			_probe_sent = false
+			_transport_type = TransportType.POLLING
+			_ping_interval = 0
+			_pong_timeout = 0
+			_max_payload = 0
+			var t := Timer.new()
+			t.wait_time = reconnect_base_delay * _reconnect_attempts
+			t.one_shot = true
+			t.timeout.connect(engine_make_connection)
+			t.timeout.connect(t.queue_free)
+			add_child(t)
+			t.start()
+		else:
+			_reconnect_attempts = 0
+			engine_close()
 			
 		
 func engine_send(data: String):
@@ -132,6 +158,7 @@ func _clear_values():
 	_ping_interval = 0
 	_pong_timeout = 0
 	_max_payload = 0
+	_reconnect_attempts = 0
 
 
 func _parse_packet(data: String):
@@ -146,7 +173,7 @@ func _parse_packet(data: String):
 			EnginePacketType.PING:
 				_on_ping()
 			EnginePacketType.PONG:
-				_on_pong()
+				_on_pong(message.substr(1))
 			EnginePacketType.MESSAGE:
 				_on_message(message.substr(1))
 			EnginePacketType.NOOP:
@@ -201,6 +228,7 @@ func _on_open(body: String = ""):
 		_upgrade_transport()
 	else:
 		_transport_type = TransportType.POLLING
+		_reconnect_attempts = 0
 		engine_connection_opened.emit()
 		_poll()
 	
@@ -213,9 +241,12 @@ func _on_ping():
 	_polling_http_request.request_post(_get_url(), str(EnginePacketType.PONG))
 
 
-func _on_pong():
+func _on_pong(payload: String = ""):
+	if payload != "probe":
+		return
 	_websocket_send(EnginePacketType.UPGRADE)
 	_transport_type = TransportType.WEBSOCKET
+	_reconnect_attempts = 0
 	engine_connection_opened.emit()
 
 
@@ -225,19 +256,13 @@ func _on_message(body: String = ""):
 
 
 func _on_noop():
-	push_error("NOOP received which is not handled yet")
+	_poll()
 
 
 func _poll():
 	if not state == State.CONNECTED or not _transport_type == TransportType.POLLING:
 		return
 	_polling_http_request.request_get(_get_url())
-
-
-func _send_ping():
-	var error: int = _polling_http_request.request(_get_url(), [], HTTPClient.METHOD_POST, str(EnginePacketType.PING))
-	if error != OK:
-		push_error("An error occurred in HTTP request for EngineIO ping, error code = %d" % error)
 
 
 func _http_send_data():

--- a/addons/godot-socketio/socketio.gd
+++ b/addons/godot-socketio/socketio.gd
@@ -148,7 +148,6 @@ func disconnect_socket():
 		disconnect_namespace(ns)
 	
 	engine_close()
-	socket_disconnected.emit()
 
 
 func _on_engine_io_connection_closed():

--- a/addons/godot-socketio/socketio.gd
+++ b/addons/godot-socketio/socketio.gd
@@ -155,6 +155,9 @@ func _on_engine_io_connection_closed():
 
 
 func _on_engine_io_connection_opened():
+	for ns in _namespaces:
+		_namespaces[ns].state = State.DISCONNECTED
+		_namespaces[ns].sid = ""
 	connect_to_namespace(default_namespace, _namespaces[default_namespace].auth)
 
 


### PR DESCRIPTION


### Bug fixes

#### `_on_noop()` treated NOOP as an error
NOOP is a normal Engine.IO packet sent during polling to unblock a long-poll request. The handler was calling `push_error()`. It now calls `_poll()`, matching the behaviour of `_on_message()`.

#### `disconnect_socket()` emitted `socket_disconnected` twice
`disconnect_socket()` called `engine_close()` which already emits `engine_connection_closed` → `_on_engine_io_connection_closed()` → `socket_disconnected`. The duplicate direct `socket_disconnected.emit()` at the end of `disconnect_socket()` was removed.

#### Upgrade PONG and heartbeat PONG not distinguished
`_on_pong()` was unconditionally triggering the WebSocket upgrade flow. It now receives the raw payload and only upgrades when the payload is `"probe"`, correctly ignoring plain heartbeat PONGs from the server.

#### `State` and `TransportType` enum type annotation error
In Godot 4, inner enums on a `class_name` class cause a type mismatch between the unqualified (`State`) and fully qualified (`EngineIO.State`) names when used as type annotations. Removed the explicit type annotations on `state` and `_transport_type`, letting GDScript infer them from their initialisers.

#### Client-initiated PINGs broke Engine.IO v4
In Engine.IO v4 only the **server** sends PINGs — client-initiated PINGs are v3 behaviour and cause the server to disconnect with `transport error`. A heartbeat timer that was sending unsolicited PINGs on `pingInterval` has been removed. The existing `_on_ping()` → PONG response path is sufficient for keepalive.

---

### New feature: automatic reconnection

When the WebSocket closes unexpectedly, the client now attempts to reconnect automatically with linear backoff instead of immediately calling `engine_close()`.

Three new exported variables are exposed in the Inspector:

| Variable | Default | Description |
|---|---|---|
| `auto_reconnect` | `true` | Enable/disable automatic reconnection |
| `max_reconnect_attempts` | `5` | Give up after this many attempts |
| `reconnect_base_delay` | `1.0` | Delay multiplied by attempt count (1 s, 2 s, 3 s…) |

A new signal `reconnect_attempt(attempt: int, max: int)` is emitted on each retry so the game UI can show feedback like _"Reconnecting 2/5…"_.

On a successful reconnection `_reconnect_attempts` resets to `0` at both success paths (polling in `_on_open`, WebSocket in `_on_pong`). If all attempts are exhausted, `engine_close()` is called normally and `engine_connection_closed` fires once.
